### PR TITLE
Rendered name of shopping lists for user and all items in list

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,7 +21,7 @@ export function App() {
 		'tcl-shopping-list-path',
 		null,
 		{
-			/* use "MyvBY6DUacb6kpGB6wtE1v5QZjF2/test-list" to render list */
+			/* Replace null with the string "MyvBY6DUacb6kpGB6wtE1v5QZjF2/test-list" to render items in test-list */
 		},
 	);
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,9 @@ export function App() {
 	const [listPath, setListPath] = useStateWithStorage(
 		'tcl-shopping-list-path',
 		null,
+		{
+			/* use "MyvBY6DUacb6kpGB6wtE1v5QZjF2/test-list" to render list */
+		},
 	);
 
 	/**

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -2,7 +2,6 @@ import './Home.css';
 import { SingleList } from '../components/SingleList';
 
 export function Home({ data, setListPath }) {
-	console.log(data);
 	return (
 		<div className="Home">
 			<p>

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -11,7 +11,12 @@ export function Home({ data, setListPath }) {
 				{/* Renders the `lists` array so we can see which lists the user has access to.  */}
 				{data.map((list) => {
 					return (
-						<SingleList key={list.name} name={list.name} path={list.path} />
+						<SingleList
+							key={list.name}
+							name={list.path}
+							path={list.name / list.path}
+							setListPath={setListPath}
+						/>
 					);
 				})}
 			</ul>

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,16 +1,18 @@
 import './Home.css';
+import { SingleList } from '../components/SingleList';
 
 export function Home({ data, setListPath }) {
+	console.log(data);
 	return (
 		<div className="Home">
 			<p>
 				Hello from the home (<code>/</code>) page!
 			</p>
 			<ul>
-				{/**
-				 * TODO: write some JavaScript that renders the `lists` array
-				 * so we can see which lists the user has access to.
-				 */}
+				{/* Renders the `lists` array so we can see which lists the user has access to.  */}
+				{data.map((list) => {
+					return <SingleList name={list.name} path={list.path} />;
+				})}
 			</ul>
 		</div>
 	);

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -11,7 +11,9 @@ export function Home({ data, setListPath }) {
 			<ul>
 				{/* Renders the `lists` array so we can see which lists the user has access to.  */}
 				{data.map((list) => {
-					return <SingleList name={list.name} path={list.path} />;
+					return (
+						<SingleList key={list.name} name={list.name} path={list.path} />
+					);
 				})}
 			</ul>
 		</div>

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -14,7 +14,7 @@ export function Home({ data, setListPath }) {
 						<SingleList
 							key={list.name}
 							name={list.path}
-							path={list.name / list.path}
+							path={list.name + '/' + list.path}
 							setListPath={setListPath}
 						/>
 					);

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,7 +1,6 @@
 import { ListItem } from '../components';
 
 export function List({ data }) {
-	console.log(data);
 	return (
 		<>
 			<p>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,17 +1,17 @@
 import { ListItem } from '../components';
 
 export function List({ data }) {
+	console.log(data);
 	return (
 		<>
 			<p>
 				Hello from the <code>/list</code> page!
 			</p>
 			<ul>
-				{/**
-				 * TODO: write some JavaScript that renders the `data` array
-				 * using the `ListItem` component that's imported at the top
-				 * of this file.
-				 */}
+				{/* Renders the `data` array using the `ListItem` component that's imported at the top of this file.*/}
+				{data.map((item) => {
+					return <ListItem key={item.id} name={item.name} />;
+				})}
 			</ul>
 		</>
 	);


### PR DESCRIPTION

## Description
This PR updates the home page so that the names of the shopping list a user is subscribed to will render. It also shows the all items in a specific shopping list when navigating to the list page. For now, we needed to manually update the listPath state/variable so that we can view all the items in our test shopping list.


## Related Issue

closes #2 

## Acceptance Criteria

- [x]  In Home.jsx, the SingleList component is used to render the name of each shopping list a user is subscribed to
- [x]  In List.jsx, the ListItem component is used to render the name of each item->

## Type of Changes

- Update Feature

## Updates

### Before

![image](https://github.com/the-collab-lab/tcl-70-smart-shopping-list/assets/28488515/6aca72bb-571f-4beb-be0c-8215b248f392)

![image](https://github.com/the-collab-lab/tcl-70-smart-shopping-list/assets/28488515/0246f6f9-3658-4025-8c30-75113978d248)


### After

<img width="1171" alt="Screenshot 2024-02-06 at 5 48 12 PM" src="https://github.com/the-collab-lab/tcl-70-smart-shopping-list/assets/110392224/ac9a473f-94e2-4be4-96b7-548b9138ec5c">

![image](https://github.com/the-collab-lab/tcl-70-smart-shopping-list/assets/28488515/b8317ed4-f3d5-4a50-91da-93e3a952bbab)

## Testing Steps / QA Criteria

- From your terminal, pull down this branch with ```git pull origin gl-km-render-lists-and-items``` and check that branch out with ```git checkout gl-km-render-lists-and-items```
- In the App.jsx file, set listPath variable from  ``` ('tcl-shopping-list-path', null,) ``` to ``` ('tcl-shopping-list-path', "MyvBY6DUacb6kpGB6wtE1v5QZjF2/test-list") ```
- From your terminal, enter: ```npm start```
- Login to view the shopping lists on homepage
- Type ```localhost:{YOUR PORT NUMBER}/list``` path into your browser's address bar to view the items in shopping list