### PR TITLE
Fix sign in on Firefox with this one weird trick!

### DIFF
--- a/src/api/useAuth.jsx
+++ b/src/api/useAuth.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { auth } from './config.js';
-import { GoogleAuthProvider, signInWithRedirect } from 'firebase/auth';
+import { GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
 import { addUserToDatabase } from './firebase.js';
 
 /**
@@ -11,7 +11,7 @@ import { addUserToDatabase } from './firebase.js';
 export const SignInButton = () => (
 	<button
 		type="button"
-		onClick={() => signInWithRedirect(auth, new GoogleAuthProvider())}
+		onClick={() => signInWithPopup(auth, new GoogleAuthProvider())}
 	>
 		Sign In
 	</button>


### PR DESCRIPTION
# Fix sign in on Firefox with this one weird trick!

## Description

Changes our sign-in method to "with popup" which should work better on Firefox and Safari for the time being.

## Related Issue

- [Best Practices](https://firebase.google.com/docs/auth/web/redirect-best-practices)

## Acceptance Criteria

- [ ] Can sign in to the webapp

## Type of Changes

- bug fix

## Updates

### Before

Firefox signin was broken

### After

Firefox sign in should work

## Testing Steps / QA Criteria

Please try to log in using a non-Chromium browser such as Firefox or Safari
