### PR TITLE
Issue #6: Invite existing users to shopping list

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -60,7 +60,7 @@ export function App() {
 					<Route path="/list" element={<List data={data} />} />
 					<Route
 						path="/manage-list"
-						element={<ManageList listPath={listPath} />}
+						element={<ManageList listPath={listPath} userId={userId} />}
 					/>
 				</Route>
 			</Routes>

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -138,14 +138,15 @@ export async function createList(userId, userEmail, listName) {
 export async function shareList(listPath, currentUserId, recipientEmail) {
 	// Check if current user is owner.
 	if (!listPath.includes(currentUserId)) {
-		return;
+		throw new Error('You are not the owner of this list');
 	}
 	// Get the document for the recipient user.
 	const usersCollectionRef = collection(db, 'users');
 	const recipientDoc = await getDoc(doc(usersCollectionRef, recipientEmail));
 	// If the recipient user doesn't exist, we can't share the list.
+
 	if (!recipientDoc.exists()) {
-		return;
+		throw new Error('User not found');
 	}
 	// Add the list to the recipient user's sharedLists array.
 	const listDocumentRef = doc(db, listPath);

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -4,6 +4,11 @@ import { addItem } from '../api';
 export function ManageList({ listPath }) {
 	const [item, setItem] = useState({ name: '', urgency: 'soon' });
 	const [submitted, setSubmitted] = useState();
+	const [emailInvite, setEmailInvite] = useState('');
+
+	const handleEmailInviteChange = (e) => {
+		setEmailInvite(e.target.value);
+	};
 
 	const handleChange = (e) => {
 		setItem({ ...item, [e.target.name]: e.target.value });
@@ -65,6 +70,18 @@ export function ManageList({ listPath }) {
 				<button type="submit" value="Submit">
 					Submit
 				</button>
+			</form>
+
+			<form>
+				<label htmlFor="emailInvite">Email invite</label>
+				<input
+					id="emailInvite"
+					placeholder="Type user email to invite"
+					name="emailInvite"
+					type="email"
+					onChange={handleEmailInviteChange}
+				/>
+				<button>Submit</button>
 			</form>
 		</div>
 	);

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -1,13 +1,26 @@
 import { useState } from 'react';
-import { addItem } from '../api';
+import { addItem, shareList } from '../api';
 
-export function ManageList({ listPath }) {
+export function ManageList({ listPath, userId }) {
 	const [item, setItem] = useState({ name: '', urgency: 'soon' });
 	const [submitted, setSubmitted] = useState();
 	const [emailInvite, setEmailInvite] = useState('');
+	const [emailExists, setEmailExists] = useState();
 
 	const handleEmailInviteChange = (e) => {
 		setEmailInvite(e.target.value);
+	};
+
+	const handleEmailInviteSubmit = async (e) => {
+		e.preventDefault();
+		try {
+			await shareList(listPath, userId, emailInvite);
+
+			setEmailExists('exists');
+		} catch (err) {
+			console.log(err);
+			setEmailExists('emailNotFound');
+		}
 	};
 
 	const handleChange = (e) => {
@@ -71,8 +84,11 @@ export function ManageList({ listPath }) {
 					Submit
 				</button>
 			</form>
-
-			<form>
+			{emailExists === 'exists' && (
+				<span>The list was successfully shared!</span>
+			)}
+			{emailExists === 'emailNotFound' && <span>The email was not found!</span>}
+			<form onSubmit={handleEmailInviteSubmit}>
 				<label htmlFor="emailInvite">Email invite</label>
 				<input
 					id="emailInvite"

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -16,6 +16,7 @@ export function ManageList({ listPath, userId }) {
 		try {
 			await shareList(listPath, userId, emailInvite);
 			setEmailExists('Your list was shared!');
+			setEmailInvite('');
 		} catch (err) {
 			console.log(err);
 			setEmailExists(err.message);
@@ -92,6 +93,7 @@ export function ManageList({ listPath, userId }) {
 					name="emailInvite"
 					type="email"
 					onChange={handleEmailInviteChange}
+					value={emailInvite}
 				/>
 				<button>Submit</button>
 			</form>

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -15,11 +15,10 @@ export function ManageList({ listPath, userId }) {
 		e.preventDefault();
 		try {
 			await shareList(listPath, userId, emailInvite);
-
-			setEmailExists('exists');
+			setEmailExists('Your list was shared!');
 		} catch (err) {
 			console.log(err);
-			setEmailExists('emailNotFound');
+			setEmailExists(err.message);
 		}
 	};
 
@@ -84,10 +83,7 @@ export function ManageList({ listPath, userId }) {
 					Submit
 				</button>
 			</form>
-			{emailExists === 'exists' && (
-				<span>The list was successfully shared!</span>
-			)}
-			{emailExists === 'emailNotFound' && <span>The email was not found!</span>}
+			{emailExists}
 			<form onSubmit={handleEmailInviteSubmit}>
 				<label htmlFor="emailInvite">Email invite</label>
 				<input


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

## Description

-It adds a form to the `ManageList` to input email.
-It updates the shareList function in `firebase.js` so that it throws errors when the user doesn't exist or shares a list that they are not the owner of.
-It shows the user if the form was successfully submitted or shows the different error messages.

## Related Issue

closes #6 

## Acceptance Criteria

- [ ]  The ManageList view shows a form that allows the user to enter an email to invite an existing user to a list, in addition to the form that allows them to add items to that list.
- [ ]   The input that accepts the email has a semantic label element associated with it
- [ ]   The user can submit this form with both the mouse and the Enter key
- [ ]   If the other user exists, the user is alerted that the list was shared
- [ ]   If the other user does not exist, the user is shown an error message that explains the problem

## Type of Changes

New Feature
Bug Fix

## Updates

### Before

<img width="744" alt="Screenshot 2024-02-22 at 12 20 28 PM" src="https://github.com/the-collab-lab/tcl-70-smart-shopping-list/assets/110392224/2af67541-34f6-4a28-8fc6-0ffa05cce92c">

### After

<img width="878" alt="Screenshot 2024-02-22 at 12 20 38 PM" src="https://github.com/the-collab-lab/tcl-70-smart-shopping-list/assets/110392224/5e4d41d0-3eb5-4a82-9515-58ba184d77ff">

## Testing Steps / QA Criteria

-From your terminal, pull down this branch with `git pull origin gl-lc-invite-to-existing-shopping-list` and check out with `git checkout gl-lc-invite-to-existing-shopping-list`
-Then enter `npm start`
-Make sure you are logged in. Enter an a non-existing email or click on a list in the home page that you are not the owner of to see the error message. Then enter an existing user's email to see the list successfully shared.
