### PR TITLE
Issue #11 | Estimate Next Purchase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
 		"": {
 			"name": "smart-shopping-list-next",
 			"dependencies": {
+				"@the-collab-lab/shopping-list-utils": "^2.2.0",
 				"firebase": "^10.1.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
@@ -3992,6 +3993,15 @@
 			},
 			"peerDependencies": {
 				"@testing-library/dom": ">=7.21.4"
+			}
+		},
+		"node_modules/@the-collab-lab/shopping-list-utils": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@the-collab-lab/shopping-list-utils/-/shopping-list-utils-2.2.0.tgz",
+			"integrity": "sha512-nEN1z/SEOIWO+8JWIgPDNUkrXmXqNomSh5aiZDNdiaUH/JYqyNeXmEOldtMqAfLicSRiFkapcAIlrUUnPzNaog==",
+			"peerDependencies": {
+				"react": "^18.2.0",
+				"react-dom": "^18.2.0"
 			}
 		},
 		"node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"npm": ">=8.19.0"
 	},
 	"dependencies": {
+		"@the-collab-lab/shopping-list-utils": "^2.2.0",
 		"firebase": "^10.1.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -190,16 +190,25 @@ export async function updateItem(listPath, itemId, dateLastPurchased) {
 	}
 	const item = itemSnapshot.data();
 
-	const effectiveDateLastPurchased = dateLastPurchased
-		? dateLastPurchased.toDate()
-		: new Date();
-
 	const previousEstimate = item.daysUntilNextPurchase;
 
-	const daysSinceLastPurchase = getDaysBetweenDates(
-		new Date(),
-		effectiveDateLastPurchased,
-	);
+	const itemCreated = item.dateCreated;
+
+	let daysSinceLastPurchase;
+
+	if (dateLastPurchased) {
+		daysSinceLastPurchase = getDaysBetweenDates(
+			new Date(),
+			dateLastPurchased.toDate(),
+		);
+	} else if (!getDaysBetweenDates(new Date(), itemCreated.toDate())) {
+		daysSinceLastPurchase = previousEstimate;
+	} else {
+		daysSinceLastPurchase = getDaysBetweenDates(
+			new Date(),
+			itemCreated.toDate(),
+		);
+	}
 
 	let nextPurchaseEstimate = calculateEstimate(
 		previousEstimate,
@@ -208,7 +217,7 @@ export async function updateItem(listPath, itemId, dateLastPurchased) {
 	);
 
 	await updateDoc(listCollectionRef, {
-		dateLastPurchased: effectiveDateLastPurchased,
+		dateLastPurchased: new Date(),
 		totalPurchases: increment(1),
 		dateNextPurchased: getFutureDate(nextPurchaseEstimate),
 		daysUntilNextPurchase: nextPurchaseEstimate,

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -201,7 +201,7 @@ export async function updateItem(listPath, itemId, dateLastPurchased) {
 			new Date(),
 			dateLastPurchased.toDate(),
 		);
-	} else if (getDaysBetweenDates(new Date(), itemCreated.toDate()) !== 0) {
+	} else if (getDaysBetweenDates(new Date(), itemCreated.toDate()) === 0) {
 		daysSinceLastPurchase = previousEstimate;
 	} else {
 		daysSinceLastPurchase = getDaysBetweenDates(

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -201,7 +201,7 @@ export async function updateItem(listPath, itemId, dateLastPurchased) {
 			new Date(),
 			dateLastPurchased.toDate(),
 		);
-	} else if (!getDaysBetweenDates(new Date(), itemCreated.toDate())) {
+	} else if (getDaysBetweenDates(new Date(), itemCreated.toDate()) !== 0) {
 		daysSinceLastPurchase = previousEstimate;
 	} else {
 		daysSinceLastPurchase = getDaysBetweenDates(

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -190,11 +190,15 @@ export async function updateItem(listPath, itemId, dateLastPurchased) {
 	}
 	const item = itemSnapshot.data();
 
+	const effectiveDateLastPurchased = dateLastPurchased
+		? dateLastPurchased.toDate()
+		: new Date();
+
 	const previousEstimate = item.daysUntilNextPurchase;
 
 	const daysSinceLastPurchase = getDaysBetweenDates(
 		new Date(),
-		dateLastPurchased.toDate(),
+		effectiveDateLastPurchased,
 	);
 
 	let nextPurchaseEstimate = calculateEstimate(
@@ -204,7 +208,7 @@ export async function updateItem(listPath, itemId, dateLastPurchased) {
 	);
 
 	await updateDoc(listCollectionRef, {
-		dateLastPurchased: new Date(),
+		dateLastPurchased: effectiveDateLastPurchased,
 		totalPurchases: increment(1),
 		dateNextPurchased: getFutureDate(nextPurchaseEstimate),
 		daysUntilNextPurchase: nextPurchaseEstimate,

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -11,7 +11,7 @@ import {
 } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { db } from './config';
-import { getFutureDate } from '../utils';
+import { getFutureDate, getDaysBetweenDates } from '../utils';
 import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
 /**
@@ -178,7 +178,6 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 		dateNextPurchased: getFutureDate(daysUntilNextPurchase),
 		name: itemName,
 		totalPurchases: 0,
-		// estimate: nextPurchasedDate,
 	});
 }
 
@@ -192,14 +191,10 @@ export async function updateItem(listPath, itemId, dateLastPurchased) {
 	const item = itemSnapshot.data();
 
 	const previousEstimate = item.daysUntilNextPurchase;
-	const totalPurchases = item.totalPurchases;
 
-	const daysSinceLastPurchase =
-		(new Date().getTime() - dateLastPurchased.toDate().getTime()) /
-		(1000 * 3600 * 24);
-
-	console.log(
-		`Previous estimate: ${previousEstimate}, Days since last purchase: ${daysSinceLastPurchase}, Total Purchase:${totalPurchases}`,
+	const daysSinceLastPurchase = getDaysBetweenDates(
+		new Date(),
+		dateLastPurchased.toDate(),
 	);
 
 	let nextPurchaseEstimate = calculateEstimate(
@@ -207,7 +202,7 @@ export async function updateItem(listPath, itemId, dateLastPurchased) {
 		daysSinceLastPurchase,
 		item.totalPurchases + 1,
 	);
-	console.log(`Next purchase estimate (in days): ${nextPurchaseEstimate}`);
+
 	await updateDoc(listCollectionRef, {
 		dateLastPurchased: new Date(),
 		totalPurchases: increment(1),

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -35,7 +35,7 @@ export function ListItem({ name, listPath, itemId, dateLastPurchased }) {
 	useEffect(() => {
 		const handleUpdateItem = async () => {
 			if (isChecked) {
-				await updateItem(listPath, itemId);
+				await updateItem(listPath, itemId, dateLastPurchased);
 			}
 		};
 		try {

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -10,3 +10,21 @@ export const ONE_DAY_IN_MILLISECONDS = 86400000;
 export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
+
+export function getDaysBetweenDates(dateOne, dateTwo) {
+	const dateOneInMilli = dateOne.getTime();
+	const dateTwoInMilli = dateTwo.getTime();
+
+	let differenceInMilli;
+	let differenceInDays;
+
+	if (dateOneInMilli > dateTwoInMilli) {
+		differenceInMilli = dateOneInMilli - dateTwoInMilli;
+	} else {
+		differenceInMilli = dateTwoInMilli - dateOneInMilli;
+	}
+
+	differenceInDays = Math.floor(differenceInMilli / ONE_DAY_IN_MILLISECONDS);
+
+	return differenceInDays;
+}

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -64,7 +64,15 @@ export function List({ data, listPath }) {
 				<ul>
 					{/* Renders the `data` array using the `ListItem` component that's imported at the top of this file.*/}
 					{filteredData.map((item) => {
-						return <ListItem key={item.id} name={item.name} />;
+						return (
+							<ListItem
+								key={item.id}
+								dateLastPurchased={item.dateLastPurchased}
+								itemId={item.id}
+								name={item.name}
+								listPath={listPath}
+							/>
+						);
 					})}
 				</ul>
 			</div>


### PR DESCRIPTION
## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->
When a user purchase an item, the dateNextPurchased property in firebase is calculated using the calculateEstimate function and saved to the Firestore database
## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->
close #11 
## Acceptance Criteria
- [x] When the user purchases an item, the item’s `dateNextPurchased` property is calculated using the `calculateEstimate` function and saved to the Firestore database
  - [x] `dateNextPurchased` is saved as **a date**, not a number
- [x] A `getDaysBetweenDates` function is exported from `utils/dates.js`  and imported into `api/firebase.js`
  - [x] This function takes two JavaScript Dates and return the number of days that have passed between them
<!-- Include AC from the Github issue -->

## Type of Changes
Enhancement

## Updates

### Before
<img width="556" alt="image" src="https://github.com/the-collab-lab/tcl-70-smart-shopping-list/assets/121919044/f0054f07-4141-4351-ad90-208a77462c6c">

<!-- If UI feature, take provide screenshots -->

### After

<!-- If UI feature, take provide screenshots -->
<img width="556" alt="image" src="https://github.com/the-collab-lab/tcl-70-smart-shopping-list/assets/121919044/1e1476aa-1da4-4909-be24-55174f599ea9">

## Testing Steps / QA Criteria

- From your terminal, pull down this branch with `git pull origin ag-gl-estimate-next-purchase-date` and check that branch out with `git checkout ag-gl-estimate-next-purchase-date`
- Enter `npm install` to install new dependencies (@the-collab-lab/shopping-list-utils)
- In the terminal enter `npm start`
- In the browser go to http://localhost:3000/
- Go to firestore for any certain item
- Click that item as purchased
- The item propety dateNextPurchased will be updated based on `calculateEstimate` from the `@the-collab-lab/shopping-list-utils` module