### PR TITLE
Removed delete and edit icons from card and added functionality to show owner of shared card

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -9,6 +9,10 @@ import {
 	addDoc,
 	increment,
 	deleteDoc,
+	query,
+	where,
+	limit,
+	getDocs,
 } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { db } from './config';
@@ -292,4 +296,22 @@ export const calculateUrgency = (daysUntilNextPurchase, dateLastPurchased) => {
 	} else if (!daysSinceLastPurchase) {
 		return 'inactive';
 	}
+};
+
+//Find user details based on id	c
+
+export const findUserDetails = async (listUserId, currentUser) => {
+	let name;
+	const q = await query(
+		collection(db, 'users'),
+		limit(1),
+		where('uid', '==', listUserId),
+		where('uid', '!=', currentUser),
+	);
+	await getDocs(q).then((res) => {
+		res.forEach(async (doc) => {
+			name = await doc.data().name;
+		});
+	});
+	return name;
 };

--- a/src/components/SingleList.jsx
+++ b/src/components/SingleList.jsx
@@ -16,7 +16,6 @@ import {
 	IconButton,
 	ButtonGroup,
 	Stack,
-	Typography,
 } from '@mui/material';
 
 import { shareList, findUserDetails } from '../api/firebase.js';

--- a/src/components/SingleList.jsx
+++ b/src/components/SingleList.jsx
@@ -1,13 +1,18 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import './SingleList.css';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../api/useAuth.jsx';
 import icons from '../utils/icons.js';
-import DeleteIcon from '@mui/icons-material/Delete';
 import ShareIcon from '@mui/icons-material/Share';
-import EditIcon from '@mui/icons-material/Edit';
-import { Modal, Box, Card, CardContent } from '@mui/material';
-import { shareList } from '../api/firebase.js';
+import {
+	Modal,
+	Box,
+	Card,
+	CardContent,
+	Typography,
+	Button,
+} from '@mui/material';
+import { shareList, findUserDetails } from '../api/firebase.js';
 
 const style = {
 	position: 'absolute',
@@ -36,6 +41,13 @@ export function SingleList({ name, path, setListPath, userId }) {
 	const iconIndex = generateIconIndexFromPath(path);
 	const icon = icons[iconIndex];
 
+	const [ownerName, setOwnerName] = useState('');
+	const userIdFromPath = path.split('/')[0];
+
+	useEffect(() => {
+		findUserDetails(userIdFromPath, userId).then((res) => setOwnerName(res));
+	}, [userIdFromPath, userId]);
+
 	// Converts path to a consistent icon index by hashing. This ensures the same path always selects the same icon.
 	function generateIconIndexFromPath(str) {
 		let hash = 0;
@@ -49,13 +61,6 @@ export function SingleList({ name, path, setListPath, userId }) {
 	function handleViewClick() {
 		setListPath(path);
 		navigate('/list');
-	}
-
-	function handleManageClick() {
-		if (currentUserIsOwner) {
-			setListPath(path);
-			navigate('/manage-list');
-		}
 	}
 
 	const handleEmailInviteChange = (e) => {
@@ -94,11 +99,25 @@ export function SingleList({ name, path, setListPath, userId }) {
 					</button>
 					{currentUserIsOwner && (
 						<>
-							<div className="icon-container">
-								<EditIcon onClick={handleManageClick} />
-								<ShareIcon onClick={handleOpenModal} />
-								<DeleteIcon onClick={handleManageClick} />
-							</div>
+							<Button
+								onClick={handleOpenModal}
+								sx={{ width: '100%', textAlign: 'center' }}
+							>
+								<Typography
+									sx={{
+										textAlign: 'center',
+										fontSize: '1.5rem',
+										color: '#003780',
+										fontWeight: '600',
+										textTransform: 'none',
+									}}
+								>
+									Share this list{' '}
+								</Typography>{' '}
+								<ShareIcon
+									sx={{ color: '#003780', margin: '0 5px', fontSize: '1.5rem' }}
+								/>
+							</Button>
 							<Modal
 								open={openModal}
 								onClose={handleCloseModal}
@@ -124,6 +143,18 @@ export function SingleList({ name, path, setListPath, userId }) {
 								</Box>
 							</Modal>
 						</>
+					)}
+					{!currentUserIsOwner && (
+						<Typography
+							sx={{
+								textAlign: 'center',
+								fontSize: '1.5rem',
+								color: '#003780',
+								fontWeight: '600',
+							}}
+						>
+							Shared by {ownerName}
+						</Typography>
 					)}
 				</CardContent>
 			</Card>


### PR DESCRIPTION
## Description

This code adds a function that searches the firestore database for user details using a users id. The id for each card is taken from the path string. If the user id does not match the current user id (id of the user signed in) then the card show's the name of the owner of the list.
Both the delete and edit icons were also removed.

## Related Issue

closes #58 

## Acceptance Criteria

- [x] The delete and edit icons should be removed and replaced by a button that has the share icon and the text "Share this list"
- [x] The share button should be fully functional
- [x] On shared lists, there should be text that tells the user that is shared. If possible it should tell the user who shared the list with them (e.g. "Shared by {name of user})

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|  ✓    | :sparkles: Enhancements     |

## Updates

### Before

![image](https://github.com/the-collab-lab/tcl-70-smart-shopping-list/assets/28488515/7cc4a79b-bf71-474a-8abf-12a3baeb61ed)

### After

![image](https://github.com/the-collab-lab/tcl-70-smart-shopping-list/assets/28488515/544684b7-6283-4405-8f3d-10ed3ca6d076)


## Testing Steps / QA Criteria

* From your terminal, pull down this branch with `git pull origin km-list-icons` and check that branch out with `git checkout km-list-icons` 
* In your browser, go to `http://localhost:3000/`
* Sign in to view changes to the list cards on the home page
* Test the functionality of the share button on cards